### PR TITLE
id_site always 1.

### DIFF
--- a/lib/piwik_analytics/configuration.rb
+++ b/lib/piwik_analytics/configuration.rb
@@ -15,7 +15,7 @@ module PiwikAnalytics
     # Defaults to 1
     #
     def id_site
-      @id_size ||= (user_configuration_from_key('id_size') || 1)
+      @id_site ||= (user_configuration_from_key('id_site') || 1)
     end
 
     #


### PR DESCRIPTION
Small change to fix a typo in configuration.rb. 

The id_site was always wrong, due to a reference to id_si_z_e.
