### PR TITLE
Add Ghostery-dodging javascript code

### DIFF
--- a/app/views/piwik_analytics/piwik_tracking_tag.html.erb
+++ b/app/views/piwik_analytics/piwik_tracking_tag.html.erb
@@ -7,7 +7,13 @@
     var piwikTracker = Piwik.getTracker(pkBaseURL + "piwik.php", <%= id_site %>);
     piwikTracker.trackPageView();
     piwikTracker.enableLinkTracking();
-  } catch( err ) {}
+  } catch( err ) {
+      (function() {
+        var img = document.createElement('img');
+        img.src = "//<%= url %>/piwik.php?idsite=<%= id_site %>&rec=1";
+        document.body.appendChild(img);
+    })();
+  }
 </script>
 <!-- End Piwik Tag -->
 <!-- Piwik Image Tracker -->

--- a/app/views/piwik_analytics/piwik_tracking_tag.html.erb
+++ b/app/views/piwik_analytics/piwik_tracking_tag.html.erb
@@ -1,7 +1,6 @@
 <!-- Piwik -->
 <script type="text/javascript">
   var pkBaseURL = (("https:" == document.location.protocol) ? "https" : "http") + "://<%= url %>/";
-  document.write(unescape("%3Cscript src='" + pkBaseURL + "piwik.js' type='text/javascript'%3E%3C/script%3E"));
   </script><script type="text/javascript">
   try {
     var piwikTracker = Piwik.getTracker(pkBaseURL + "piwik.php", <%= id_site %>);


### PR DESCRIPTION
Hey There,

I implemented for my own use a way to prevent Ghostery from disabling the image tracker (link of the source given in commit body) that seems to be working well for me, feel free to add it to your repository.

Best, Bertrand
- Ghostery ignores the <noscript> part
  -> Implemented js solution given here : http://forum.piwik.org/read.php?2,87735,page=1
