### PR TITLE
Use `template` instead of `file` to render the piwik template

### DIFF
--- a/lib/piwik_analytics/helpers.rb
+++ b/lib/piwik_analytics/helpers.rb
@@ -5,7 +5,7 @@ module PiwikAnalytics
       return if config.disabled?
 
       render({
-        file: "piwik_analytics/piwik_tracking_tag",
+        template: "piwik_analytics/piwik_tracking_tag",
         locals: {url: config.url, id_site: config.id_site}
       })
     end

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -30,10 +30,10 @@ describe PiwikAnalytics::Helpers do
         @double.piwik_tracking_tag
       end
 
-      it 'should use file piwik_tracking_tag' do
+      it 'should use template piwik_tracking_tag' do
         allow(PiwikAnalytics).to receive(:configuration).and_return(@config)
 
-        expect(@double).to receive(:render).with(hash_including(file: 'piwik_analytics/piwik_tracking_tag'))
+        expect(@double).to receive(:render).with(hash_including(template: 'piwik_analytics/piwik_tracking_tag'))
         @double.piwik_tracking_tag
       end
     end


### PR DESCRIPTION
This makes the gem compatible with Rails 6.1, which removed support for passing a relative path to `file`.

Fixes https://github.com/halfdan/piwik-ruby-tracking/issues/27